### PR TITLE
Remove Docker login requirement

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,9 +13,6 @@ jobs:
       run: |
         docker build -t ${{ env.REGISTRY }}/current-time:latest .
         
-    - name: Login to registry
-      run: |
-        echo ${{ secrets.DOCKER_PASSWORD }} | docker login ${{ env.REGISTRY }} -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
     - name: Push image
       run: |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,5 @@ docker push 173.249.48.147:5000/current-time:latest
 ```
 
 
-Aucune étape de connexion n'est requise pour ce registre public. Le workflow GitHub Actions publiera automatiquement l'image lors des pushs sur la branche `main`.
-
-Configurez les secrets `DOCKER_USERNAME` et `DOCKER_PASSWORD` dans votre dépôt GitHub pour que le workflow puisse publier automatiquement l'image.
+Le registre est public, aucune étape de connexion n'est nécessaire. Le workflow GitHub Actions publiera automatiquement l'image lors des pushs sur la branche `main`.
 


### PR DESCRIPTION
## Summary
- remove the Docker login step from the workflow
- clarify in the README that pushing the image doesn't require login

## Testing
- `git status --short`