### PR TITLE
Add dynamic clock page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.11-slim
 WORKDIR /app
 COPY app app
 COPY requirements.txt requirements.txt
+COPY index.html index.html
 RUN pip install --no-cache-dir -r requirements.txt
 EXPOSE 80
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "80"]

--- a/app/main.py
+++ b/app/main.py
@@ -1,9 +1,11 @@
 from fastapi import FastAPI
-from app.routes import users, products
+from fastapi.responses import HTMLResponse
+from pathlib import Path
 
-from app.routes import categories, clients
+from app.routes import users, products, categories, clients
 
-app = FastAPI(title="Product Catalog API")
+
+app = FastAPI(title="Product Catalog API", docs_url="/swagger")
 
 app.include_router(users.router)
 app.include_router(products.router)
@@ -11,8 +13,12 @@ app.include_router(categories.router)
 app.include_router(clients.router)
 
 
+@app.get("/", response_class=HTMLResponse)
+def read_index():
+    """Serve the main HTML page with the dynamic clock."""
+    index_path = Path(__file__).resolve().parent.parent / "index.html"
+    return HTMLResponse(index_path.read_text(encoding="utf-8"))
 
-app = FastAPI(title="Product Catalog API", docs_url="/swagger")
 
 if __name__ == "__main__":
     import uvicorn


### PR DESCRIPTION
## Summary
- serve a clock page at the root URL
- include index.html in the Docker image

## Testing
- `pytest -q`